### PR TITLE
[FE] 기본 export와 import 설정 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ dist-ssr
 .env.*
 
 # Editor directories and files
-.vscode/*
+!.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit"
+    },
+    "editor.formatOnSave": true
+}


### PR DESCRIPTION
이 PR은 LoginPage.jsx 파일과 Dashboard.jsx 파일로 컴포넌트를 분리하여 default export 중복 문제를 해결합니다.

주요 변경 사항:

LoginPage.jsx 파일에는 LoginPage 컴포넌트만 남김.
Dashboard.jsx 파일에 DashboardPage 컴포넌트 코드를 이동.
App.jsx에서 올바른 스타일 파일 import 경로로 수정 ("./styles/App.css").
로컬에서 npm run dev로 테스트하여 두 페이지가 정상적으로 렌더링되는 것을 확인했습니다.

리뷰 후 develop 브랜치에 머지 부탁드립니다.