### PR TITLE
[FE] [#18] 커리큘럼 단계별 공부자료 추천 기능 구현

### DIFF
--- a/src/pages/CurriculumList.jsx
+++ b/src/pages/CurriculumList.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import useCurriculumStore from "../../stores/curriculumStore";
 import ProgressCircle from "../components/common/ProgressCircle";
 import "../styles/CurriculumList.css";
+import { FiChevronDown, FiChevronUp } from "react-icons/fi";
 
 const CurriculumList = () => {
   //여러 개의 커리큘럼 객체가 들어있는 배열 curriculum
@@ -12,6 +13,11 @@ const CurriculumList = () => {
     isLoading,
     toggleCompleteStep,
     progressMap,
+    recommendations,
+    fetchRecommendations,
+    expandedSteps,
+    toggleExpandedStep,
+    loadingSteps,
   } = useCurriculumStore();
 
   useEffect(() => {
@@ -50,28 +56,73 @@ const CurriculumList = () => {
                     삭제
                   </button>
                 </div>
+
                 <div className="step-list">
                   {Object.entries(curri.curriculumMap)
                     .sort(([a], [b]) => Number(a) - Number(b))
-                    .map(([step, detail]) => (
-                      <div
-                        key={step}
-                        className={`step-item ${detail.completed ? "completed" : ""}`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={detail.completed}
-                          onChange={() =>
-                            toggleCompleteStep(
-                              curri.id,
-                              step,
-                              !detail.completed
-                            )
-                          }
-                        />
-                        <strong>Step {step}:</strong> {detail.description}
-                      </div>
-                    ))}
+                    .map(([step, detail]) => {
+                      const key = `${curri.id}-${step}`;
+                      const isExpanded = expandedSteps.has(key);
+                      const isLoading = loadingSteps.has(key);
+                      const recs = recommendations[key] || [];
+
+                      return (
+                        <div key={step}>
+                          <div
+                            className={`step-item ${detail.completed ? "completed" : ""}`}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={detail.completed}
+                              onChange={() =>
+                                toggleCompleteStep(
+                                  curri.id,
+                                  step,
+                                  !detail.completed
+                                )
+                              }
+                            />
+                            <strong>Step {step}:</strong> {detail.description}
+                            <button
+                              className="toggle-recommend-btn"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (expandedSteps.has(key)) {
+                                  toggleExpandedStep(key);
+                                } else {
+                                  fetchRecommendations(curri.id, step);
+                                }
+                              }}
+                            >
+                              {isExpanded ? <FiChevronUp /> : <FiChevronDown />}
+                            </button>
+                          </div>
+
+                          {isExpanded && (
+                            <div className="recommendation-list">
+                              {isLoading ? (
+                                <p>자료 불러오는 중...</p>
+                              ) : (
+                                recs.map((item, idx) => (
+                                  <div
+                                    key={idx}
+                                    className="recommendation-item"
+                                  >
+                                    <a
+                                      href={item.link}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                    >
+                                      {item.title}
+                                    </a>
+                                  </div>
+                                ))
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
                 </div>
               </div>
             );

--- a/src/pages/CurriculumList.jsx
+++ b/src/pages/CurriculumList.jsx
@@ -22,7 +22,7 @@ const CurriculumList = () => {
 
   useEffect(() => {
     fetchCurriculumList();
-  }, []);
+  }, [fetchCurriculumList]);
 
   if (isLoading) {
     return <p className="empty-message">불러오는 중입니다...</p>;

--- a/src/styles/CurriculumList.css
+++ b/src/styles/CurriculumList.css
@@ -85,3 +85,26 @@
 .step-item.completed {
   color: gray;
 }
+
+.recommendation-list {
+  margin-top: 8px;
+  padding-left: 20px;
+  border-left: 2px solid #6ed3c7;
+  background-color: hsl(0, 10%, 90%);
+  border-radius: 8px;
+  transition: all 0.3s ease;
+}
+
+.recommendation-item {
+  padding: 4px 0;
+  font-size: 0.95rem;
+}
+
+.recommendation-item a {
+  color: #111;
+  text-decoration: none;
+}
+
+.recommendation-item a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

#18 

## 🛠 작업 내용

- 각 커리큘럼 단계별 GPT 추천 자료 조회 기능 구현
- 추천 자료는 중복 요청 방지, 다중 확장 상태 및 토글 상태로 관리
- 더미 데이터 제거 및 실제 API 연동 완료

## ✅ 체크리스트

- [x] 커밋 메시지가 컨벤션에 맞게 작성되었는가?
- [x] 변경 사항에 대한 테스트를 수행했는가?
- [x] 리뷰어가 확인할 수 있도록 충분한 설명을 작성했는가?
