### PR TITLE
[FE] 대시보드 페이지 구현 완료

### DIFF
--- a/src/components/dashboard/CalendarMiniCard.jsx
+++ b/src/components/dashboard/CalendarMiniCard.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import "../../styles/CalendarMiniCard.css";
@@ -6,19 +7,30 @@ import { format } from "date-fns";
 import useGoalStore from "../../../stores/goalStore";
 
 const CalendarMiniCard = () => {
+  const navigate = useNavigate();
   const [value, setValue] = useState(new Date());
   const { goals, fetchGoals } = useGoalStore();
+
+  const thisYear = new Date().getFullYear();
+  const minDate = new Date(thisYear, 0, 1);
+  const maxDate = new Date(thisYear, 11, 31);
 
   useEffect(() => {
     fetchGoals();
   }, []);
 
   return (
-    <div>
+    <div className="calendar-scale">
       <Calendar
         onChange={setValue}
         value={value}
+        onClickDay={(value) => {
+          const dateStr = format(value, "yyyy-MM-dd");
+          navigate(`/calendar?date=${dateStr}`);
+        }}
         locale="en-us"
+        minDate={minDate}
+        maxDate={maxDate}
         formatShortWeekday={(locale, date) =>
           ["Sun", "Mon", "Tue", "Wed", "Thr", "Fri", "Sat"][date.getDay()]
         }
@@ -39,9 +51,6 @@ const CalendarMiniCard = () => {
             </div>
           );
         }}
-        tileClassName={({ date }) =>
-          date.getMonth() !== value.getMonth() ? "hide-other-month" : ""
-        }
       />
     </div>
   );

--- a/src/components/dashboard/CalendarMiniCard.jsx
+++ b/src/components/dashboard/CalendarMiniCard.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from "react";
+import Calendar from "react-calendar";
+import "react-calendar/dist/Calendar.css";
+import "../../styles/CalendarMiniCard.css";
+import { format } from "date-fns";
+import useGoalStore from "../../../stores/goalStore";
+
+const CalendarMiniCard = () => {
+  const [value, setValue] = useState(new Date());
+  const { goals, fetchGoals } = useGoalStore();
+
+  useEffect(() => {
+    fetchGoals();
+  }, []);
+
+  return (
+    <div>
+      <Calendar
+        onChange={setValue}
+        value={value}
+        locale="en-us"
+        formatShortWeekday={(locale, date) =>
+          ["Sun", "Mon", "Tue", "Wed", "Thr", "Fri", "Sat"][date.getDay()]
+        }
+        tileContent={({ date }) => {
+          const dayStr = format(date, "yyyy-MM-dd");
+          const goalsForDay = goals.filter((goal) => goal.deadLine === dayStr);
+          const hasIncomplete = goalsForDay.some((goal) => !goal.completed);
+          const icon =
+            goalsForDay.length > 0 ? (hasIncomplete ? "💦" : "✅") : null;
+
+          return (
+            <div className="calendar-icon">
+              {icon ? (
+                <span>{icon}</span>
+              ) : (
+                <span style={{ visibility: "hidden" }}>💦</span>
+              )}
+            </div>
+          );
+        }}
+        tileClassName={({ date }) =>
+          date.getMonth() !== value.getMonth() ? "hide-other-month" : ""
+        }
+      />
+    </div>
+  );
+};
+
+export default CalendarMiniCard;

--- a/src/components/dashboard/CurriculumProgressCard.jsx
+++ b/src/components/dashboard/CurriculumProgressCard.jsx
@@ -1,28 +1,62 @@
 import React, { useEffect } from "react";
 import useCurriculumStore from "../../../stores/curriculumStore";
 import ProgressCircle from "../common/ProgressCircle";
+import { useNavigate } from "react-router-dom";
 import "../../styles/CurriculumProgressCard.css";
 
 const CurriculumProgressCard = () => {
   const { curriculums, progressMap, fetchCurriculumList } =
     useCurriculumStore();
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchCurriculumList();
   }, []);
 
+  const topCurris = curriculums;
+  const bgColors = ["#F0F7FF", "#FFF0F7", "#F0FFF3", "#FFF5F0"];
+  const nmColors = [
+    "rgba(0, 119, 255, 0.5)",
+    "rgba(255, 29, 134, 0.5)",
+    "rgba(22, 208, 59, 0.5)",
+    "rgba(255, 126, 62, 0.5)",
+  ];
+
   return (
-    <div>
-      {curriculums.length === 0 ? (
+    <div className="curriculum-progress-wrapper">
+      <h2 className="progress-title">📚 진행 중인 커리큘럼</h2>
+      {topCurris.length === 0 ? (
         <p>커리큘럼이 없습니다.</p>
       ) : (
         <div className="curriculum-progress-list">
-          {curriculums.map((curri) => {
+          {topCurris.map((curri, idx) => {
             const percent = progressMap[curri.id] ?? 0;
             return (
-              <div className="curriculum-progress-item" key={curri.id}>
-                <span className="topic">{curri.topic}</span>
-                <ProgressCircle value={percent} />
+              <div
+                className="curriculum-progress-item"
+                key={curri.id}
+                style={{
+                  backgroundColor: bgColors[idx % bgColors.length],
+                  cursor: "pointer",
+                }}
+                onClick={() =>
+                  navigate("/CurriculumList", {
+                    state: { highlightId: curri.id },
+                  })
+                }
+              >
+                <div className="curriculum-card-left">
+                  <div
+                    className="curriculum-number"
+                    style={{ backgroundColor: nmColors[idx % nmColors.length] }}
+                  >
+                    {idx + 1}
+                  </div>
+                  <div className="curriculum-topic-name">{curri.topic}</div>
+                </div>
+                <div className="curriculum-card-right">
+                  <ProgressCircle value={percent} />
+                </div>
               </div>
             );
           })}

--- a/src/components/dashboard/CurriculumProgressCard.jsx
+++ b/src/components/dashboard/CurriculumProgressCard.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from "react";
+import useCurriculumStore from "../../../stores/curriculumStore";
+import ProgressCircle from "../common/ProgressCircle";
+import "../../styles/CurriculumProgressCard.css";
+
+const CurriculumProgressCard = () => {
+  const { curriculums, progressMap, fetchCurriculumList } =
+    useCurriculumStore();
+
+  useEffect(() => {
+    fetchCurriculumList();
+  }, []);
+
+  return (
+    <div>
+      {curriculums.length === 0 ? (
+        <p>커리큘럼이 없습니다.</p>
+      ) : (
+        <div className="curriculum-progress-list">
+          {curriculums.map((curri) => {
+            const percent = progressMap[curri.id] ?? 0;
+            return (
+              <div className="curriculum-progress-item" key={curri.id}>
+                <span className="topic">{curri.topic}</span>
+                <ProgressCircle value={percent} />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CurriculumProgressCard;

--- a/src/pages/CalendarPage.jsx
+++ b/src/pages/CalendarPage.jsx
@@ -63,10 +63,6 @@ const CalendarPage = () => {
                 ["Sun", "Mon", "Tue", "Wed", "Thr", "Fri", "Sat"][date.getDay()]
               }
               formatDay={(locale, date) => date.getDate().toString()}
-              tileClassName={({ date }) => {
-                const isOtherMonth = date.getMonth() !== value.getMonth();
-                return isOtherMonth ? "hide-other-month" : "";
-              }}
               tileContent={({ date }) => {
                 const dayStr = format(date, "yyyy-MM-dd");
                 const goalsForDay = goals.filter(

--- a/src/pages/CalendarPage.jsx
+++ b/src/pages/CalendarPage.jsx
@@ -7,6 +7,7 @@ import GoalModal from "../components/GoalModal";
 import useGoalStore from "../../stores/goalStore";
 import "../styles/CalendarPage.css";
 import { useNavigate } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
 const CalendarPage = () => {
   const [value, setValue] = useState(new Date());
@@ -16,7 +17,20 @@ const CalendarPage = () => {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [isEdit, setIsEdit] = useState(false);
   const [initialGoal, setInitialGoal] = useState(null);
+  const [searchParams] = useSearchParams();
+
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const param = searchParams.get("date");
+    if (param) {
+      const parsed = new Date(param);
+      if (!isNaN(parsed)) {
+        setSelectedDate(parsed);
+        setValue(parsed);
+      }
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     const loadGoals = async () => {

--- a/src/pages/CurriculumList.jsx
+++ b/src/pages/CurriculumList.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import useCurriculumStore from "../../stores/curriculumStore";
 import ProgressCircle from "../components/common/ProgressCircle";
 import "../styles/CurriculumList.css";
 import { FiChevronDown, FiChevronUp } from "react-icons/fi";
+import { useLocation } from "react-router-dom";
 
 const CurriculumList = () => {
   //여러 개의 커리큘럼 객체가 들어있는 배열 curriculum
@@ -20,9 +21,22 @@ const CurriculumList = () => {
     loadingSteps,
   } = useCurriculumStore();
 
+  const location = useLocation();
+  const highlightId = location.state?.highlightId;
+  const cardRefs = useRef({});
+
   useEffect(() => {
     fetchCurriculumList();
   }, [fetchCurriculumList]);
+
+  useEffect(() => {
+    if (highlightId && cardRefs.current[highlightId]) {
+      cardRefs.current[highlightId].scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+  }, [curriculums, highlightId]);
 
   if (isLoading) {
     return <p className="empty-message">불러오는 중입니다...</p>;
@@ -39,7 +53,11 @@ const CurriculumList = () => {
             const percent = progressMap[curri.id] || 0;
 
             return (
-              <div className="curriculum-card" key={curri.id}>
+              <div
+                ref={(el) => (cardRefs.current[curri.id] = el)}
+                className={`curriculum-card ${curri.id === highlightId ? "highlight" : ""}`}
+                key={curri.id}
+              >
                 <div className="curriculum-header">
                   <div className="topic-progress-wrap">
                     <h2 className="curriculum-topic">📘 {curri.topic}</h2>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,11 +1,44 @@
-import React from "react";
+import React, { useEffect } from "react";
 import StudyTimer from "../components/common/StudyTimer";
+import useAuthStore from "../../stores/authStore";
+import useStudyStatStore from "../../stores/studyStatStore";
+import CalendarMiniCard from "../components/dashboard/CalendarMiniCard";
+import CurriculumProgressCard from "../components/dashboard/CurriculumProgressCard";
 
 const Dashboard = () => {
+  const { user } = useAuthStore();
+  const { streakCount, fetchStreakCount } = useStudyStatStore();
+
+  useEffect(() => {
+    if (user?.userId) {
+      fetchStreakCount(user.userId);
+    }
+  }, [user?.userId]);
+
   return (
-    <div>
-      <h1>DashBoard</h1>
-      <StudyTimer />
+    <div className="dashboard-container">
+      <div className="greeting-section">
+        <h2>{user?.nickname}님, 안녕하세요 👋</h2>
+        <p>🔥 {streakCount ?? 0}일째 공부중입니다!</p>
+      </div>
+
+      <div className="dashboard-grid">
+        <div className="main-timer-card">
+          <StudyTimer />
+        </div>
+
+        <div className="calendar-card">
+          <CalendarMiniCard />
+        </div>
+
+        <div className="curriculum-card">
+          <CurriculumProgressCard />
+        </div>
+
+        <div className="message-card">
+          <p>메시지 기능 준비중...</p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import useAuthStore from "../../stores/authStore";
 import useStudyStatStore from "../../stores/studyStatStore";
 import CalendarMiniCard from "../components/dashboard/CalendarMiniCard";
 import CurriculumProgressCard from "../components/dashboard/CurriculumProgressCard";
+import "../styles/Dashboard.css";
 
 const Dashboard = () => {
   const { user } = useAuthStore();
@@ -16,27 +17,30 @@ const Dashboard = () => {
   }, [user?.userId]);
 
   return (
-    <div className="dashboard-container">
-      <div className="greeting-section">
-        <h2>{user?.nickname}님, 안녕하세요 👋</h2>
-        <p>🔥 {streakCount ?? 0}일째 공부중입니다!</p>
-      </div>
+    <div>
+      <div className="greeting-and-cards">
+        <div className="greeting-left">
+          <div className="greeting-section">
+            <h2>{user?.nickname}님, 안녕하세요 👋</h2>
+            <p>🔥 {streakCount ?? 0}일째 공부중입니다!</p>
+          </div>
 
-      <div className="dashboard-grid">
-        <div className="main-timer-card">
-          <StudyTimer />
+          <div className="left-card">
+            <StudyTimer />
+          </div>
         </div>
 
-        <div className="calendar-card">
+        <div className="right-card">
           <CalendarMiniCard />
         </div>
+      </div>
 
-        <div className="curriculum-card">
-          <CurriculumProgressCard />
-        </div>
-
-        <div className="message-card">
+      <div className="card-grid">
+        <div className="full-card message-card">
           <p>메시지 기능 준비중...</p>
+        </div>
+        <div className="full-card">
+          <CurriculumProgressCard />
         </div>
       </div>
     </div>

--- a/src/styles/CalendarMiniCard.css
+++ b/src/styles/CalendarMiniCard.css
@@ -1,0 +1,14 @@
+.react-calendar {
+  width: 100%;
+  border: none;
+  font-family: inherit;
+}
+
+.calendar-icon {
+  text-align: center;
+  font-size: 0.8rem;
+}
+
+.hide-other-month {
+  color: #ccc;
+}

--- a/src/styles/CalendarMiniCard.css
+++ b/src/styles/CalendarMiniCard.css
@@ -1,12 +1,77 @@
-.react-calendar {
+.calendar-scale {
+  transform-origin: top center;
   width: 100%;
+  max-width: 352px;
+  margin: 0;
+}
+
+.calendar-mini-wrapper {
+  width: 352px;
+  height: 320px;
+  display: flex;
+  overflow: visible;
+  padding: 0;
+  margin: 0;
+  justify-content: center;
+  text-align: center;
+}
+
+.react-calendar {
+  font-size: 0.85rem;
+  width: 100%;
+  max-width: 350px;
+  height: 410px;
+  transform-origin: top center;
   border: none;
   font-family: inherit;
+  background-color: #ffffff;
+  border-radius: 20px;
+  padding: 0.5rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
+.react-calendar__month-view__days {
+  display: grid !important;
+  grid-template-columns: repeat(7, 1fr);
+  grid-template-rows: repeat(5, 1fr); /* 최대 5줄 */
+}
+
+/* 2. 각 날짜 셀을 정사각형으로 만들기 */
+.react-calendar__tile {
+  aspect-ratio: 1 / 1; /* ✅ 정사각형 만들기 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0 !important;
+  margin: 0;
+  font-size: 1;
+  overflow: hidden;
+}
+
+/* 날짜 셀을 감싸는 그리드 영역에서 마지막 줄 숨기기 */
+.react-calendar__month-view__days > .react-calendar__tile:nth-child(n + 36) {
+  display: none;
+}
+
+.react-calendar__tile abbr {
+  display: block;
+  font-size: 0.9rem;
+  margin: 0;
+  padding: 0;
+  line-height: 1;
+  text-align: center;
+}
+
+.react-calendar__tile span {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 1;
 }
 
 .calendar-icon {
   text-align: center;
-  font-size: 0.8rem;
+  font-size: 0.5rem;
 }
 
 .hide-other-month {

--- a/src/styles/CalendarMiniCard.css
+++ b/src/styles/CalendarMiniCard.css
@@ -36,9 +36,8 @@
   grid-template-rows: repeat(5, 1fr); /* 최대 5줄 */
 }
 
-/* 2. 각 날짜 셀을 정사각형으로 만들기 */
 .react-calendar__tile {
-  aspect-ratio: 1 / 1; /* ✅ 정사각형 만들기 */
+  aspect-ratio: 1 / 1;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -71,7 +70,7 @@
 
 .calendar-icon {
   text-align: center;
-  font-size: 0.5rem;
+  font-size: 0.8rem;
 }
 
 .hide-other-month {

--- a/src/styles/CalendarPage.css
+++ b/src/styles/CalendarPage.css
@@ -55,10 +55,6 @@
   border-bottom: none;
 }
 
-.hide-other-month {
-  visibility: hidden;
-}
-
 .react-calendar__navigation {
   margin-bottom: 0.5rem;
 }
@@ -91,7 +87,7 @@
 }
 
 .goal-list h3 {
-  margin-left: 0.9rem; /* 카드 시작 위치에 맞게 조정 */
+  margin-left: 0.9rem;
 }
 
 .goal-card-container {

--- a/src/styles/CurriculumList.css
+++ b/src/styles/CurriculumList.css
@@ -1,7 +1,11 @@
-/* CurriculumList.css */
 .curriculum-list-container {
   width: 100%;
-  padding: 2rem 2rem;
+  height: 100vh;
+  padding: 1rem 2rem;
+  min-height: 100vh;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
 
 .curriculum-title {
@@ -18,17 +22,44 @@
 }
 
 .curriculum-scroll {
-  max-height: 70vh;
+  flex: 1;
+  max-height: 100vh;
   overflow-y: auto;
   padding-right: 4px;
+
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.curriculum-scroll::-webkit-scrollbar {
+  display: none; /* Chrome, Safari */
 }
 
 .curriculum-card {
   background-color: #d8f5f2;
-  border-radius: 12px;
+  border-radius: 20px;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+}
+
+.curriculum-card:hover {
+  background-color: #e0f7ff;
+}
+
+.curriculum-card.highlight {
+  border: 2px solid #66bc22;
+  background-color: #f0fff4;
+  animation: highlight-fade 0.8s ease;
+}
+
+@keyframes highlight-fade {
+  0% {
+    background-color: #e3ffe9;
+  }
+  100% {
+    background-color: #f0fff4;
+  }
 }
 
 .curriculum-header {
@@ -39,12 +70,15 @@
 }
 
 .topic-progress-wrap {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  justify-content: space-between;
   align-items: center;
-  gap: 4px;
+  gap: 1rem;
 }
 
 .curriculum-topic {
+  flex: 1;
   font-size: 1.25rem;
   color: #333;
   background-color: white;
@@ -52,6 +86,7 @@
   padding: 2px 8px;
   margin: 0;
   display: inline-block;
+  word-break: keep-all;
 }
 
 .delete-button {

--- a/src/styles/CurriculumProgressCard.css
+++ b/src/styles/CurriculumProgressCard.css
@@ -1,0 +1,20 @@
+.curriculum-progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.curriculum-progress-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f4f7f9;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+}
+
+.curriculum-progress-item .topic {
+  font-weight: 600;
+  font-size: 1rem;
+}

--- a/src/styles/CurriculumProgressCard.css
+++ b/src/styles/CurriculumProgressCard.css
@@ -1,3 +1,17 @@
+.curriculum-progress-wrapper {
+  max-height: 400px; /* 원하는 만큼 줄이기 */
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 4px; /* 스크롤바 공간 확보 */
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: #6edac9 #f0f0f0;
+}
+
+.progress-title {
+  margin: 0.4rem;
+}
+
 .curriculum-progress-list {
   display: flex;
   flex-direction: column;
@@ -5,16 +19,45 @@
 }
 
 .curriculum-progress-item {
+  background: #f8f9fa;
+  border-radius: 20px;
+  padding: 0.7rem 1.2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: #f4f7f9;
-  padding: 0.75rem 1rem;
-  border-radius: 10px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+  transition: backgound-color 0.2s ease;
+}
+
+.curriculum-progress-item:hover {
+  transform: scale(1.02);
+  background-color: #e0f7ff;
 }
 
 .curriculum-progress-item .topic {
   font-weight: 600;
   font-size: 1rem;
+}
+
+.curriculum-card-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.curriculum-number {
+  color: white;
+  width: 50px;
+  height: 50px;
+  font-size: 1.3rem;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+
+.curriculum-topic-name {
+  font-size: 1rem;
+  font-weight: bold;
+  color: #333;
 }

--- a/src/styles/Dashboard.css
+++ b/src/styles/Dashboard.css
@@ -1,23 +1,82 @@
 .dashboard-container {
-  padding: 2rem;
+  padding: 1.25rem 2rem;
+  font-family: inherit;
+  overflow: hidden;
+}
+
+.greeting-and-cards {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.greeting-left {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+  max-width: 900px;
 }
 
 .greeting-section {
   margin-bottom: 1.5rem;
 }
 
-.dashboard-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
+.greeting-section h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.3rem;
+}
+
+.greeting-section p {
+  font-size: 1rem;
+  color: #666;
+}
+
+.left-card {
+  height: auto;
+  max-height: 100%;
+}
+.right-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  box-shadow: none;
+  height: auto;
+  overflow: visible;
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.grid-section {
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
 }
 
-.main-timer-card,
-.calendar-card,
-.curriculum-card,
-.message-card {
-  background: #f9f9f9;
-  padding: 1.5rem;
+.card-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.full-card {
+  background: #fff;
+  padding: 1rem;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+  height: auto;
+}
+
+.message-card {
+  text-align: center;
+  color: #666;
+  font-size: 1rem;
+  padding: 0.75rem;
+  min-height: 50px;
+  height: auto;
 }

--- a/src/styles/Dashboard.css
+++ b/src/styles/Dashboard.css
@@ -1,0 +1,23 @@
+.dashboard-container {
+  padding: 2rem;
+}
+
+.greeting-section {
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+.main-timer-card,
+.calendar-card,
+.curriculum-card,
+.message-card {
+  background: #f9f9f9;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}

--- a/src/styles/ProgressCircle.css
+++ b/src/styles/ProgressCircle.css
@@ -2,6 +2,7 @@
   width: 100px;
   height: 70px;
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
 }

--- a/src/styles/TimerCard.css
+++ b/src/styles/TimerCard.css
@@ -4,8 +4,14 @@
   padding: 24px;
   text-align: center;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-  width: 280px;
+  width: 100%;
+  max-width: 900px;
+  height: 300px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 .timer-label {


### PR DESCRIPTION
## 🔗 관련 이슈

## 🛠 작업 내용

- 대시보드 UI 전체 레이아웃 구성
  - 공부 시간 타이머 구현 및 상태 관리
  - `CalendarMiniCard.jsx` 캘린더 구현 ( 올해 날짜 범위 제한, todo 완료 상태에 따른 아이콘 표시, 클릭시 캘린더 페이지의 해당 날짜로 이동 )
  - `CurriculumProgressCard` 진행 중인 커리큘럼 카드 구현 (개별 클릭시 커리큘럼 목록 페이지로 이동, 이동 후 해당 커리큘럼 카드 강조 + 자동 스크롤 처리)
  - 연속 공부 일수 연동 
  - ❌메시지 기능은 추후 별도 구현 예정

## ✅ 체크리스트

- [x] 커밋 메시지가 컨벤션에 맞게 작성되었는가?
- [x] 변경 사항에 대한 테스트를 수행했는가?
- [x] 리뷰어가 확인할 수 있도록 충분한 설명을 작성했는가?
