### PR TITLE
[FE] [#30] 로그인 및 인증 토큰 처리 방식 개선 및 상태 복원 로직 추가

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -1,15 +1,23 @@
 import axios from "axios";
 
 const apiClient = axios.create({
-  baseURL: "/api",
+  baseURL: "http://localhost:8080/api",
   timeout: 10000,
+  withCredentials: true,
 });
 
 apiClient.interceptors.request.use(
   (config) => {
     const accessToken = localStorage.getItem("accessToken");
-    if (accessToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
+    console.log("💥 interceptor - token from localStorage:", accessToken);
+    if (accessToken && accessToken !== "undefined") {
+      config.headers["Authorization"] = `Bearer ${accessToken}`;
+      console.log(
+        "✅ Authorization header 붙음:",
+        config.headers["Authorization"]
+      );
+    } else {
+      delete config.headers["Authorization"]; // 혹시라도 헤더에 남아있을 경우 제거
     }
     return config;
   },
@@ -24,11 +32,12 @@ apiClient.interceptors.response.use(
     if (
       error.response &&
       error.response.status === 401 &&
+      error.response.headers["X-Token-Expired"] === "true" &&
       !originalRequest._retry
     ) {
       originalRequest._retry = true;
       try {
-        const refreshResponse = await axios.post("/api/user/refresh-token");
+        const refreshResponse = await apiClient.post("/user/refresh-token");
         const newAccessToken = refreshResponse.data.accessToken;
 
         localStorage.setItem("accessToken", newAccessToken);

--- a/src/pages/GeneratedCurriculum.jsx
+++ b/src/pages/GeneratedCurriculum.jsx
@@ -69,19 +69,23 @@ const GeneratedCurriculum = ({ curriculum, topic }) => {
     <div className="curriculum-result-container">
       <h1 className="curriculum-title">이 커리큘럼 어때요?☺️</h1>
       <div className="curriculum-box">
-      <textarea
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        readOnly={!isEditable}
-        rows={10}
-        style={{ width: "80%", marginTop: "20px" }}
-      />
-      <div className="curriculum-btn-group">
-        <button className="curriculum-btn edit" onClick={handleEdit}>수정</button>
-        <button className="curriculum-btn confirm" onClick={handleConfirm}>확인</button>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          readOnly={!isEditable}
+          rows={10}
+          style={{ width: "80%", marginTop: "20px" }}
+        />
+        <div className="curriculum-btn-group">
+          <button className="curriculum-btn edit" onClick={handleEdit}>
+            수정
+          </button>
+          <button className="curriculum-btn confirm" onClick={handleConfirm}>
+            확인
+          </button>
+        </div>
+        {error && <p style={{ color: "red" }}>{error}</p>}
       </div>
-      {error && <p style={{ color: "red" }}>{error}</p>}
-    </div>
     </div>
   );
 };

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import apiClient from "../lib/apiClient";
-import { useNavigate } from "react-router-dom";
 import "../styles/Login.css";
 import useAuthStore from "../../stores/authStore";
 
@@ -13,8 +12,6 @@ const Login = () => {
   const [error, setError] = useState(null);
 
   const { setUser } = useAuthStore();
-
-  const navigate = useNavigate();
 
   const onChange = (e) => {
     const { name, value } = e.target;
@@ -33,10 +30,15 @@ const Login = () => {
         password: input.password,
       });
 
+      console.log("🔥 로그인 응답:", response.data);
+
       //accessToken 저장
-      const rawHeader = response.headers["authorization"];
-      const accessToken = rawHeader?.split(" ")[1];
+      const accessToken = response.data.accessToken;
       localStorage.setItem("accessToken", accessToken);
+      console.log(
+        "✅ 저장된 accessToken:",
+        localStorage.getItem("accessToken")
+      );
 
       //사용자 정보 저장
       const userData = {
@@ -48,8 +50,7 @@ const Login = () => {
 
       console.log("로그인에 성공했습니다.", response.data);
 
-      //로그인 성공 후 사용자를 대시보드 등 보호된 페이지로 이동
-      navigate("/dashboard");
+      window.location.href = "/dashboard";
     } catch (err) {
       setError("로그인에 실패했습니다.");
       console.error(err);

--- a/src/router/AppRoutes.jsx
+++ b/src/router/AppRoutes.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import CurriculumList from "../pages/CurriculumList";
-
+import useAuthStore from "../../stores/authStore";
 import Login from "../pages/Login";
 import Register from "../pages/Register";
 import Dashboard from "../pages/Dashboard";
@@ -17,6 +17,15 @@ import StudyTimeStat from "../pages/StudyTimeStat";
 export default function AppRoutes() {
   const [curriculum, setCurriculum] = useState(null);
   const [topic, setTopic] = useState("");
+
+  const setUser = useAuthStore((state) => state.setUser);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("user");
+    if (stored) {
+      setUser(JSON.parse(stored));
+    }
+  }, [setUser]);
 
   return (
     <Router>


### PR DESCRIPTION
## 🔗 관련 이슈

#30 

## 🛠 작업 내용

- `Login.jsx`
  - accessToken 전달 방식 수정: 응답의 HTTP body에서 accessToken을 추출하는 구조로 변경했습니다.
  - window.location.href 도입: 로그인 직후 `navigate()` 대신 강제 새로고침 방식으로 accessToken 저장 직후의 반영 문제 해결했습니다.
  - 디버깅 로그를 추가했습니다.
  - 불필요한 코드를 제거했습니다.
- `AppRoutes.jsx`
  - Zustand 전역 상태 복원: 새로고침 시에도 로그인 상태가 유지되도록 localStorage의 user 정보를 Zustand에 반영하는 useEffect 추가합니다.
- `apiClient.js`
  - baseURL 명시: 로컬 통합 테스트 편의를 위한 명시적 주소를 설정합니다.
  - withCredential 설정 추가: refreshToken이 담긴 httpOnly 쿠키 전송을 위해 설정했습니다.
  - Authorization 헤더 처리 강화: accessToken이 없는 경우 기존 헤더를 삭제 처리하고, `undefined`인 경우 예외를 방지합니다.
  - 토큰 만료 대응 개선: 백엔드에서 `X-Token-Expired` 헤더로 만료 여부를 판단하고 refreshToken 요청 흐름을 구현했습니다.

## ✅ 체크리스트

- [x] 커밋 메시지가 컨벤션에 맞게 작성되었는가?
- [x] 변경 사항에 대한 테스트를 수행했는가?
- [x] 리뷰어가 확인할 수 있도록 충분한 설명을 작성했는가?
